### PR TITLE
Zabbix proxy 3.0 fixes

### DIFF
--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -3,7 +3,7 @@
 
 - name: "RedHat | Set some facts"
   set_fact: 
-    datafiles_path: "/usr/share/doc/zabbix-proxy-{{ database_type }}-{{ zabbix_version }}*/create"
+    datafiles_path: "/usr/share/doc/zabbix-proxy-{{ database_type }}-{{ zabbix_version }}*"
 
 - name: "RedHat | Install basic repo file"
   template: src=rhel.repo.j2

--- a/tasks/mysql.yml
+++ b/tasks/mysql.yml
@@ -17,4 +17,10 @@
   shell: "cd {{ datafiles_path }} && mysql -u {{ proxy_dbuser }} -p{{ proxy_dbpassword }} -D {{ proxy_dbname }} < schema.sql && touch /etc/zabbix/schema.done"
   args:
     creates: /etc/zabbix/schema.done
-  when: manage_database_sqlload and ansible_os_family == "RedHat"
+  when: manage_database_sqlload and ansible_os_family == "RedHat" and (zabbix_version == '2.2' or zabbix_version == '2.4')
+
+- name: "MySQL | Importing schema file"
+  shell: "cd {{ datafiles_path }} && zcat schema.sql.gz | mysql -u {{ proxy_dbuser }} -p{{ proxy_dbpassword }} -D {{ proxy_dbname }} && touch /etc/zabbix/schema.done"
+  args:
+    creates: /etc/zabbix/schema.done
+  when: manage_database_sqlload and ansible_os_family == "RedHat" and zabbix_version == 3.0

--- a/templates/zabbix_proxy.conf.j2
+++ b/templates/zabbix_proxy.conf.j2
@@ -269,11 +269,13 @@ StartDBSyncers={{ proxy_startdbsyncers }}
 #
 HistoryCacheSize={{ proxy_historycachesize -}}M
 
+{% if zabbix_version == '2.2' or zabbix_version == '2.4' %}
 ### Option: HistoryTextCacheSize
 #	Size of text history cache, in bytes.
 #	Shared memory size for storing character, text or log history data.
 #
 HistoryTextCacheSize={{ proxy_historytextcachesize -}}M
+{% endif %}
 
 ### Option: Timeout
 #	Specifies how long we wait for agent, SNMP device or external check (in seconds).


### PR DESCRIPTION
a few fixes:
- bad datafiles_path (extra /create) for RedHat
- zabbix-proxy RPM comes with a compressed SQL schema (add zcat)
- add conditional in the proxy conf due to `HistoryTextCacheSize` being deprecated in 3.0
