### PR TITLE
[!] fix misspelling with property ListenIP

### DIFF
--- a/templates/zabbix_proxy.conf.j2
+++ b/templates/zabbix_proxy.conf.j2
@@ -243,7 +243,7 @@ StartSNMPTrapper={{ proxy_snmptrapper }}
 #	Trapper will listen on all network interfaces if this parameter is missing.
 #
 {% if proxy_listenip is defined and proxy_listenip %}
-ListenIp={{ proxy_listenip }}
+ListenIP={{ proxy_listenip }}
 {% endif %}
 
 ### Option: HousekeepingFrequency


### PR DESCRIPTION
current & wrong: ListenIp
correct: ListenIP

example of error:
> "msg": "zabbix_proxy [27861]: unknown parameter \"ListenIp\" in config file \"/etc/zabbix/zabbix_proxy.conf\", line 208\n"}
