### PR TITLE
set selinux policy to permissive for zabbix_t, needed for CentOS and others

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,6 +35,14 @@
     group: zabbix
     state: directory
 
+- name: "Allow zabbix_proxy to start (SELinux)"
+  selinux_permissive:
+    name: zabbix_t
+    permissive: true
+  become: yes
+  when:
+    - zabbix_selinux
+
 - name: "Configure zabbix-proxy"
   template:
     src: zabbix_proxy.conf.j2


### PR DESCRIPTION
This is essentially a backport from your zabbix-agent role. I needed this to make zabbix-proxy work under CentOS 7, probably other RH-based as well. 