### PR TITLE
Various changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ There are some variables in de default/main.yml which can (Or needs to) be chang
 There are some zabbix-proxy specific variables which will be used for the zabbix-proxy configuration file, these can be found in the default/main.yml file. There are 2 which needs some explanation:
 
 ```bash
-  #database_type: mysql
-  #database_type_long: mysql
-  database_type: pgsql
-  database_type_long: postgresql
+  #zabbix_proxy_database: mysql
+  #zabbix_proxy_database_long: mysql
+  zabbix_proxy_database: pgsql
+  zabbix_proxy_database_long: postgresql
 ```
 
 There are 2 database_types which will be supported: mysql and postgresql. You'll need to comment or uncomment the database you would like to use. In example from above, the postgresql database is used. If you want to use mysql, uncomment the 2 lines from mysql and comment the 2 lines for postgresql.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,10 +25,10 @@ zabbix_database_creation: True
 zabbix_database_sqlload: True
 
 # Some role specific vars
-database_type: mysql
-database_type_long: mysql
-#database_type: pgsql
-#database_type_long: postgresql
+zabbix_proxy_database: mysql
+zabbix_proxy_database_long: mysql
+#zabbix_proxy_database: pgsql
+#zabbix_proxy_database_long: postgresql
 
 # zabbix-proxy specifc vars
 zabbix_proxy_mode: 0

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Installing and maintaining zabbix-proxy for RedHat/Debian/Ubuntu.
   company: myCompany.Dotcom
   license: license (GPLv3)
-  min_ansible_version: 1.4
+  min_ansible_version: 2.4
   platforms:
     - name: EL
       versions:
@@ -19,6 +19,7 @@ galaxy_info:
       versions:
         - squeeze
         - wheezy
+        - stretch
   categories:
     - monitoring
 dependencies: []

--- a/molecule/default/create.yml
+++ b/molecule/default/create.yml
@@ -39,7 +39,7 @@
         image: "molecule_local/{{ item.image }}"
         state: started
         recreate: False
-        log_driver: syslog
+        log_driver: none
         command: "{{ item.command | default('sleep infinity') }}"
         privileged: "{{ item.privileged | default(omit) }}"
         volumes: "{{ item.volumes | default(omit) }}"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -19,16 +19,18 @@ platforms:
     groups:
       - postgresql
   - name: zabbix-proxy-mysql-debian
-    image: maint/debian-systemd
+    image: minimum2scp/systemd-stretch
     privileged: True
+    command: /sbin/init
     groups:
       - mysql
   - name: zabbix-proxy-pgsql-debian
-    image: maint/debian-systemd
+    image: minimum2scp/systemd-stretch
     privileged: True
+    command: /sbin/init
     groups:
       - postgresql
-  - name: zabbix-v-mysql-ubuntu
+  - name: zabbix-proxy-mysql-ubuntu
     image: solita/ubuntu-systemd:latest
     privileged: True
     command: /sbin/init
@@ -48,12 +50,12 @@ provisioner:
   inventory:
     group_vars:
       mysql:
-        database_type: mysql
-        database_type_long: mysql
-        server_dbport: 3306
+        zabbix_database_type: mysql
+        zabbix_database_type_long: mysql
+        zabbix_server_dbport: 3306
       postgresql:
-        database_type: pgsql
-        database_type_long: postgresql
+        zabbix_database_type: pgsql
+        zabbix_database_type_long: postgresql
 
 scenario:
   name: default

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -7,6 +7,7 @@ lint:
   name: yamllint
   options:
     config-file: molecule/default/yaml-lint.yml
+
 platforms:
   - name: zabbix-proxy-mysql-centos
     image: milcom/centos7-systemd
@@ -50,12 +51,12 @@ provisioner:
   inventory:
     group_vars:
       mysql:
-        zabbix_database_type: mysql
-        zabbix_database_type_long: mysql
-        zabbix_server_dbport: 3306
+        zabbix_proxy_database: mysql
+        zabbix_proxy_database_long: mysql
+        zabbix_proxy_dbport: 3306
       postgresql:
-        zabbix_database_type: pgsql
-        zabbix_database_type_long: postgresql
+        zabbix_proxy_database: pgsql
+        zabbix_proxy_database_long: postgresql
 
 scenario:
   name: default

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -5,7 +5,7 @@
     - name: "Installing packages"
       yum:
         name: "{{ item }}"
-        state: installed
+        state: present
       with_items:
         - net-tools
         - which
@@ -16,7 +16,7 @@
     - name: "Installing which on NON-CentOS"
       apt:
         name: "{{ item }}"
-        state: installed
+        state: present
       with_items:
         - net-tools
       when: ansible_distribution != 'CentOS'

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,69 +1,60 @@
 ---
 
+- name: "Include Zabbix gpg ids"
+  include_vars: zabbix.yml
+
+- name: "Set short version name"
+  set_fact:
+    zabbix_short_version: "{{ zabbix_version | regex_replace('\\.', '') }}"
+
 - name: "Debian | Set some facts"
   set_fact:
     apache_log: apache2
-    datafiles_path: "/usr/share/zabbix-proxy-{{ database_type }}"
+    datafiles_path: "/usr/share/zabbix-proxy-{{ zabbix_proxy_database }}"
   when:
-    - zabbix_version | version_compare('3.0', '<')
+    - zabbix_version is version_compare('3.0', '<')
   tags:
-    - zabbix-server
+    - zabbix-proxt
     - init
     - config
 
 - name: "Debian | Set some facts for Zabbix 3.0"
   set_fact:
     apache_log: apache2
-    datafiles_path: "/usr/share/doc/zabbix-proxy-{{ database_type }}"
+    datafiles_path: "/usr/share/doc/zabbix-proxy-{{ zabbix_proxy_database }}"
   when:
-    - zabbix_version | version_compare('3.0', '>=')
+    - zabbix_version is version_compare('3.0', '>=')
   tags:
-    - zabbix-server
+    - zabbix-proxy
     - init
     - config
 
 - name: "Debian | Install gpg key"
   apt_key:
-    id: 79EA5ED4
+    id: "{{ sign_keys[zabbix_short_version][ansible_distribution_release]['sign_key'] }}"
     url: http://repo.zabbix.com/zabbix-official-repo.key
   when:
     - zabbix_repo == "zabbix"
+  become: yes
+  tags:
+    - zabbix-proxy
+    - init
 
-- name: "Debian | Installing repository Debian"
+- name: "Debian | Installing repository {{ ansible_distribution }}"
   apt_repository:
-    repo: "deb http://repo.zabbix.com/zabbix/{{ zabbix_version }}/debian/ {{ ansible_distribution_release }} main"
+    repo: "{{ item }} http://repo.zabbix.com/zabbix/{{ zabbix_version }}/{{ ansible_distribution.lower() }}/ {{ ansible_distribution_release }} main"
     state: present
-  when:
-    - ansible_distribution == "Debian"
-    - zabbix_repo == "zabbix"
+  when: zabbix_repo == "zabbix"
+  with_items:
+    - deb-src
+    - deb
+  tags:
+    - zabbix-proxy
+    - init
 
-- name: "Debian | Installing repository Debian"
-  apt_repository:
-    repo: "deb-src http://repo.zabbix.com/zabbix/{{ zabbix_version }}/debian/ {{ ansible_distribution_release }} main"
-    state: present
-  when:
-    - ansible_distribution == "Debian"
-    - zabbix_repo == "zabbix"
-
-- name: "Debian | Installing repository Ubuntu"
-  apt_repository:
-    repo: "deb http://repo.zabbix.com/zabbix/{{ zabbix_version }}/ubuntu/ {{ ansible_distribution_release }} main"
-    state: present
-  when:
-    - ansible_distribution == "Ubuntu"
-    - zabbix_repo == "zabbix"
-
-- name: "Debian | Installing repository Ubuntu"
-  apt_repository:
-    repo: "deb-src http://repo.zabbix.com/zabbix/{{ zabbix_version }}/ubuntu/ {{ ansible_distribution_release }} main"
-    state: present
-  when:
-    - ansible_distribution == "Ubuntu"
-    - zabbix_repo == "zabbix"
-
-- name: "Debian | Installing zabbix-proxy-{{ database_type }}"
+- name: "Debian | Installing zabbix-proxy-{{ zabbix_proxy_database }}"
   apt:
-    pkg: zabbix-proxy-{{ database_type }}
+    pkg: zabbix-proxy-{{ zabbix_proxy_database }}
     update_cache: yes
     cache_valid_time: 3600
     force: yes
@@ -84,7 +75,7 @@
     - mysql-client
     - python-mysqldb
   when:
-    - database_type == 'mysql'
+    - zabbix_proxy_database == 'mysql'
   tags:
     - zabbix-server
     - init
@@ -95,7 +86,7 @@
     name: postgresql
     state: present
   when:
-    - database_type == 'pgsql'
+    - zabbix_proxy_database == 'pgsql'
   tags:
     - zabbix-server
     - init

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -4,20 +4,20 @@
 - name: "RedHat | Set some facts Zabbix < 3.0"
   set_fact:
     apache_log: httpd
-    datafiles_path: "/usr/share/doc/zabbix-proxy-{{ database_type }}-{{ zabbix_version }}*/create"
+    datafiles_path: "/usr/share/doc/zabbix-proxy-{{ zabbix_proxy_database }}-{{ zabbix_version }}*/create"
   when:
-    - zabbix_version | version_compare('3.0', '<')
+    - zabbix_version is version_compare('3.0', '<')
   tags:
-    - zabbix-server
+    - zabbix-proxy
 
 - name: "RedHat | Set facts for Zabbix >= 3.0"
   set_fact:
     apache_log: httpd
-    datafiles_path: "/usr/share/doc/zabbix-proxy-{{ database_type }}-{{ zabbix_version }}*"
+    datafiles_path: "/usr/share/doc/zabbix-proxy-{{ zabbix_proxy_database }}-{{ zabbix_version }}*"
   when:
-    - zabbix_version | version_compare('3.0', '>=')
+    - zabbix_version is version_compare('3.0', '>=')
   tags:
-    - zabbix-server
+    - zabbix-proxy
 
 - name: "RedHat | Install basic repo file"
   yum_repository:
@@ -33,7 +33,7 @@
 
 - name: "RedHat | Installing zabbix-proxy-database_type"
   yum:
-    pkg: zabbix-proxy-{{ database_type }}
+    pkg: zabbix-proxy-{{ zabbix_proxy_database }}
     state: present
 
 - name: "RedHat | Install Ansible module dependencies"
@@ -54,7 +54,7 @@
     - mariadb
     - MySQL-python
   when:
-    - database_type == 'mysql'
+    - zabbix_proxy_database == 'mysql'
     - ansible_distribution_major_version == '7'
   tags:
     - zabbix-proxy
@@ -68,7 +68,7 @@
     - mysql
     - MySQL-python
   when:
-    - database_type == 'mysql'
+    - zabbix_proxy_database == 'mysql'
     - ansible_distribution_major_version != '7'
   tags:
     - zabbix-proxy
@@ -80,7 +80,7 @@
     name: postgresql
     state: present
   when:
-    - database_type == 'pgsql'
+    - zabbix_proxy_database == 'pgsql'
   tags:
     - zabbix-proxy
     - init

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
     - ansible_os_family == "Debian"
 
 - name: "Installing the database"
-  include: "{{ database_type_long }}.yml"
+  include: "{{ zabbix_proxy_database_long }}.yml"
 
 - name: "Create include dir zabbix-proxy"
   file:

--- a/templates/zabbix_proxy.conf.j2
+++ b/templates/zabbix_proxy.conf.j2
@@ -208,7 +208,7 @@ JavaGatewayPort={{ zabbix_proxy_javagatewayport }}
 StartJavaPollers={{ zabbix_proxy_startjavapollers }}
 {% endif %}
 
-{% if zabbix_version | version_compare('2.4', '>=') %}
+{% if zabbix_version is version_compare('2.4', '>=') %}
 ### Option: StartVMwareCollectors
 #	Number of pre-forked vmware collector instances.
 #
@@ -269,7 +269,7 @@ StartDBSyncers={{ zabbix_proxy_startdbsyncers }}
 #
 HistoryCacheSize={{ zabbix_proxy_historycachesize -}}M
 
-{% if zabbix_version | version_compare('3.2', '>=') %}
+{% if zabbix_version is version_compare('3.2', '>=') %}
 ### Option: HistoryIndexCacheSize
 # Size of history index cache, in bytes.
 # Shared memory size for indexing history cache.
@@ -280,7 +280,7 @@ HistoryCacheSize={{ zabbix_proxy_historycachesize -}}M
 HistoryIndexCacheSize={{ zabbix_proxy_historyindexcachesize -}}M
 {% endif %}
 
-{% if zabbix_version | version_compare('2.4', '<') %}
+{% if zabbix_version is version_compare('2.4', '<') %}
 ### Option: HistoryTextCacheSize
 #	Size of text history cache, in bytes.
 #	Shared memory size for storing character, text or log history data.
@@ -351,7 +351,7 @@ LogSlowQueries={{ zabbix_proxy_loglowqueries }}
 #
 TmpDir={{ zabbix_proxy_tmpdir }}
 
-{% if zabbix_version | version_compare('2.4', '<') %}
+{% if zabbix_version is version_compare('2.4', '<') %}
 ### Option: AllowRoot
 #	Allow the proxy to run as 'root'. If disabled and the proxy is started by 'root', the proxy
 #	will try to switch to user 'zabbix' instead. Has no effect if started under a regular user.
@@ -369,7 +369,7 @@ Include={{ zabbix_proxy_include }}
 
 ####### LOADABLE MODULES #######
 
-{% if zabbix_version | version_compare('3.0', '<') %}
+{% if zabbix_version is version_compare('3.0', '<') %}
 ### Option: LoadModulePath
 #	Full path to location of proxy modules.
 #	Default depends on compilation options.
@@ -387,7 +387,7 @@ LoadModulePath={{ zabbix_proxy_loadmodulepath }}
 LoadModule={{ zabbix_proxy_loadmodule }}
 {% endif %}
 
-{% if zabbix_version | version_compare('3.0', '>=') %}
+{% if zabbix_version is version_compare('3.0', '>=') %}
 ####### TLS-RELATED PARAMETERS #######
 
 ### Option: TLSConnect

--- a/vars/zabbix.yml
+++ b/vars/zabbix.yml
@@ -1,0 +1,80 @@
+---
+
+sign_keys:
+  "34":
+    bionic:
+      sign_key: A14FE591
+    sonya:
+      sign_key: A14FE591
+    serena:
+      sign_key: A14FE591
+    stretch:
+      sign_key: A14FE591
+    wheezy:
+      sign_key: 79EA5ED4
+    jessie:
+      sign_key: 79EA5ED4
+    trusty:
+      sign_key: 79EA5ED4
+    xenial:
+      sign_key: E709712C
+  "32":
+    sonya:
+      sign_key: 79EA5ED4
+    serena:
+      sign_key: 79EA5ED4
+    stretch:
+      sign_key: A14FE591
+    wheezy:
+      sign_key: 79EA5ED4
+    jessie:
+      sign_key: 79EA5ED4
+    trusty:
+      sign_key: 79EA5ED4
+    xenial:
+      sign_key: E709712C
+  "30":
+    wheezy:
+      sign_key: 79EA5ED4
+    jessie:
+      sign_key: 79EA5ED4
+    stretch:
+      sign_key: A14FE591
+    trusty:
+      sign_key: 79EA5ED4
+    xenial:
+      sign_key: E709712C
+  "24":
+    wheezy:
+      sign_key: 79EA5ED4
+    jessie:
+      sign_key: 79EA5ED4
+    precise:
+      sign_key: 79EA5ED4
+    trusty:
+      sign_key: 79EA5ED4
+  "22":
+    squeeze:
+      sign_key: 79EA5ED4
+    jessie:
+      sign_key: 79EA5ED4
+    precise:
+      sign_key: 79EA5ED4
+    trusty:
+      sign_key: 79EA5ED4
+    lucid:
+      sign_key: 79EA5ED4
+
+suse:
+  "openSUSE Leap":
+    "42":
+      name: server:monitoring
+      url: http://download.opensuse.org/repositories/server:/monitoring/openSUSE_Leap_{{ ansible_distribution_version }}/
+  "openSUSE":
+    "12":
+      name: server_monitoring
+      url: http://download.opensuse.org/repositories/server:/monitoring/openSUSE_{{ ansible_distribution_version }}
+  "SLES":
+    "11":
+      name: server_monitoring
+      url: http://download.opensuse.org/repositories/server:/monitoring/SLE_11_SP3/


### PR DESCRIPTION
This PR contains the following changes:

* Use 2.4 as minimum;
* Use Debian 9;
* Make proper use of variables `zabbix_proxy_database` & `zabbix_proxy_database_long` to get inline with the `zabbix-server` role;