### PR TITLE
typo in zabbix_proxy_cachesize variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -70,7 +70,7 @@ zabbix_proxy_snmptrapperfile: /tmp/zabbix_traps.tmp
 zabbix_proxy_snmptrapper: 0
 zabbix_proxy_listenip:
 zabbix_proxy_housekeepingfrequency: 1
-zabbix_proxy_casesize: 8
+zabbix_proxy_cachesize: 8
 zabbix_proxy_startdbsyncers: 4
 zabbix_proxy_historycachesize: 8
 zabbix_proxy_historyindexcachesize: 4

--- a/templates/zabbix_proxy.conf.j2
+++ b/templates/zabbix_proxy.conf.j2
@@ -256,7 +256,7 @@ HousekeepingFrequency={{ zabbix_proxy_housekeepingfrequency }}
 #	Size of configuration cache, in bytes.
 #	Shared memory size, for storing hosts and items data.
 #
-CacheSize={{ zabbix_proxy_casesize -}}M
+CacheSize={{ zabbix_proxy_cachesize -}}M
 
 ### Option: StartDBSyncers
 #	Number of pre-forked instances of DB Syncers


### PR DESCRIPTION
**Description of PR**
Corrected variable name `zabbix_proxy_cachesize` from `zabbix_proxy_casesize` in both `defaults.yml` and the configuration template.

**Type of change**
Bugfix Pull Request
