### PR TITLE
Adding zabbix_proxy_install_database_client variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ There are some variables in de default/main.yml which can (Or needs to) be chang
 
 * `zabbix_repo`: True / False. When you already have an repository with the zabbix components, you can set it to False.
 
+* `zabbix_proxy_install_database_client`: True / False. False does not install database client. Default: True.
+
 There are some zabbix-proxy specific variables which will be used for the zabbix-proxy configuration file, these can be found in the default/main.yml file. There are 2 which needs some explanation:
 
 ```bash

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,8 @@ zabbix_version: 4.0
 zabbix_repo: zabbix
 zabbix_selinux: False
 
+zabbix_proxy_install_database_client: True
+
 zabbix_repo_yum:
   - name: zabbix
     description: Zabbix Official Repository - $basearch

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -78,6 +78,7 @@
   when:
     - zabbix_database_creation or zabbix_database_sqlload
     - zabbix_proxy_database == 'mysql'
+    - zabbix_proxy_install_database_client
   tags:
     - zabbix-proxy
     - init
@@ -90,6 +91,7 @@
   when:
     - zabbix_database_creation or zabbix_database_sqlload
     - zabbix_proxy_database == 'pgsql'
+    - zabbix_proxy_install_database_client
   tags:
     - zabbix-proxy
     - init

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -73,6 +73,7 @@
     - zabbix_database_creation or zabbix_database_sqlload
     - zabbix_proxy_database == 'mysql'
     - ansible_distribution_major_version != '7'
+    - zabbix_proxy_install_database_client
   tags:
     - zabbix-proxy
     - init
@@ -85,6 +86,7 @@
   when:
     - zabbix_database_creation or zabbix_database_sqlload
     - zabbix_proxy_database == 'pgsql'
+    - zabbix_proxy_install_database_client
   tags:
     - zabbix-proxy
     - init


### PR DESCRIPTION
**Description of PR**
<!--- Describe what the PR holds -->
This PR adds a new variable so that we can ignore the installation of the database client so that the proxy roles behaves the same way as the server role.

**Type of change**
<!--- Pick one below and delete the rest: -->

Feature Pull Request

