### PR TITLE
Fix and refactor SELinux support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,6 @@
 
 zabbix_version: 4.2
 zabbix_repo: zabbix
-zabbix_selinux: False
 zabbix_proxy_package_state: present
 zabbix_proxy_install_database_client: True
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -66,7 +66,7 @@
   become: yes
   when: ansible_selinux.status == "enabled"
   tags: selinux
- 
+
 - name: "Configure zabbix-proxy"
   template:
     src: zabbix_proxy.conf.j2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -58,14 +58,15 @@
   notify:
     - restart zabbix-proxy
 
-- name: "Allow zabbix_proxy to start (SELinux)"
-  selinux_permissive:
-    name: zabbix_t
-    permissive: true
+- name: "Allow zabbix-proxy to open connections (SELinux)"
+  seboolean:
+    name: zabbix_can_network
+    persistent: yes
+    state: yes
   become: yes
-  when:
-    - zabbix_selinux
-
+  when: ansible_selinux.status == "enabled"
+  tags: selinux
+ 
 - name: "Configure zabbix-proxy"
   template:
     src: zabbix_proxy.conf.j2

--- a/tasks/sqlite3.yml
+++ b/tasks/sqlite3.yml
@@ -12,6 +12,9 @@
     name: "{{ zabbix_proxy_dbname | dirname }}"
     owner: zabbix
     group: zabbix
+    seuser: system_u
+    serole: object_r
+    setype: zabbix_var_lib_t
     state: directory
   when:
     - zabbix_database_creation
@@ -29,3 +32,15 @@
     PGPASSWORD: '{{ zabbix_proxy_dbpassword }}'
   when:
     - zabbix_database_creation
+
+- name: "Fix zabbix db file permission (SELinux)"
+  file:
+    path: "{{ zabbix_proxy_dbname }}"
+    state: file
+    seuser: system_u
+    serole: object_r
+    setype: zabbix_var_lib_t
+  when: 
+    - ansible_selinux.status == "enabled"
+    - zabbix_database_creation
+  tags: selinux

--- a/tasks/sqlite3.yml
+++ b/tasks/sqlite3.yml
@@ -40,7 +40,7 @@
     seuser: system_u
     serole: object_r
     setype: zabbix_var_lib_t
-  when: 
+  when:
     - ansible_selinux.status == "enabled"
     - zabbix_database_creation
   tags: selinux


### PR DESCRIPTION
**Description of PR**
This PR refactors the selinux support in this role with the following improvements:
- no longer relay on a static variable to enable selinux support but use the ansible_facts to detect if selinux is enabled or not;
- don't set permissive mode on zabbix but rather use the selinux boolean (zabbix_can_network);
- set the proper selinux labels on the /var/lib/zabbix dir and the sqlite db file;


**Type of change**
Bugfix Pull Request


**Fixes an issue**
<!--- If this PR fixes an issue, please mention it. -->
