### PR TITLE
Calling yum and apt using a loop is deprecated

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -76,11 +76,8 @@
 
 - name: "Debian | Install Mysql Client package"
   apt:
-    name: "{{ item }}"
+    name: ['mysql-client', 'python-mysqldb']
     state: present
-  with_items:
-    - mysql-client
-    - python-mysqldb
   register: are_zabbix_proxy_dependency_packages_installed
   until: are_zabbix_proxy_dependency_packages_installed is succeeded
   when:

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -53,13 +53,10 @@
 
 - name: "RedHat | Install Mysql Client package RHEL7"
   yum:
-    name: "{{ item }}"
+    name: ['mariadb', 'MySQL-python']
     state: installed
   register: are_zabbix_proxy_dependency_packages_installed
   until: are_zabbix_proxy_dependency_packages_installed is succeeded
-  with_items:
-    - mariadb
-    - MySQL-python
   when:
     - zabbix_database_creation or zabbix_database_sqlload
     - zabbix_proxy_database == 'mysql'
@@ -70,13 +67,10 @@
 
 - name: "RedHat | Install Mysql Client package RHEL5 - 6"
   yum:
-    name: "{{ item }}"
+    name: ['mysql', 'MySQL-python']
     state: present
   register: are_zabbix_proxy_dependency_packages_installed
   until: are_zabbix_proxy_dependency_packages_installed is succeeded
-  with_items:
-    - mysql
-    - MySQL-python
   when:
     - zabbix_database_creation or zabbix_database_sqlload
     - zabbix_proxy_database == 'mysql'


### PR DESCRIPTION
Calling yum and apt modules once using a loop is deprecated by Ansible and will be removed someday. Better be proactive and fix these pesky warnings.