### PR TITLE
Added missing "become: yes" statements in tasks/main.yml Redhat.yml

### DIFF
--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -27,6 +27,7 @@
     gpgcheck: "{{ item.gpgcheck }}"
     gpgkey: "{{ item.gpgkey }}"
     state: "{{ item.state | default('present') }}"
+  become: yes
   with_items: "{{ zabbix_repo_yum }}"
   tags:
     - zabbix-agent
@@ -35,6 +36,7 @@
   yum:
     pkg: zabbix-proxy-{{ zabbix_proxy_database }}
     state: "{{ zabbix_proxy_package_state }}"
+  become: yes
   register: is_zabbix_proxy_package_installed
   until: is_zabbix_proxy_package_installed is succeeded
 
@@ -42,6 +44,7 @@
   yum:
     name: python-psycopg2
     state: present
+  become: yes
   register: are_zabbix_proxy_dependency_packages_installed
   until: are_zabbix_proxy_dependency_packages_installed is succeeded
   when:
@@ -55,6 +58,7 @@
   yum:
     name: ['mariadb', 'MySQL-python']
     state: installed
+  become: yes
   register: are_zabbix_proxy_dependency_packages_installed
   until: are_zabbix_proxy_dependency_packages_installed is succeeded
   when:
@@ -69,6 +73,7 @@
   yum:
     name: ['mysql', 'MySQL-python']
     state: present
+  become: yes
   register: are_zabbix_proxy_dependency_packages_installed
   until: are_zabbix_proxy_dependency_packages_installed is succeeded
   when:
@@ -85,6 +90,7 @@
   yum:
     name: postgresql
     state: present
+  become: yes
   register: are_zabbix_proxy_dependency_packages_installed
   until: are_zabbix_proxy_dependency_packages_installed is succeeded
   when:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,6 +27,7 @@
     group: zabbix
     mode: 0755
     state: directory
+  become: yes
 
 - name: "Create module dir zabbix-proxy"
   file:
@@ -34,6 +35,7 @@
     owner: zabbix
     group: zabbix
     state: directory
+  become: yes
 
 - name: "Create directory for PSK file if not exist."
   file:
@@ -81,3 +83,4 @@
     name: zabbix-proxy
     state: started
     enabled: yes
+  become: yes


### PR DESCRIPTION
**Description of PR**
Added missing "become: yes" statements in tasks/main.yml Redhat.yml

**Type of change**
Bugfix Pull Request

**Fixes an issue**
When ansible user is unpriviledged, missing "become: yes" statemenets causes play failure on RedHat systems
