### PR TITLE
selinux blocks preprocessing workers

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -77,7 +77,7 @@
   become: yes
   when: ansible_selinux.status == "enabled"
   tags: selinux
-  
+
 - name: "Configure zabbix-proxy"
   template:
     src: zabbix_proxy.conf.j2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,6 +69,15 @@
   when: ansible_selinux.status == "enabled"
   tags: selinux
 
+- name: "Allow zabbix-proxy to connect to zabbix_proxy_preprocessing.sock (SELinux)"
+  seboolean:
+    name: daemons_enable_cluster_mode
+    persistent: yes
+    state: yes
+  become: yes
+  when: ansible_selinux.status == "enabled"
+  tags: selinux
+  
 - name: "Configure zabbix-proxy"
   template:
     src: zabbix_proxy.conf.j2


### PR DESCRIPTION
We have to enable this boolean in order to start the preprocessing workers:
daemons_enable_cluster_mode --> on

**Description of PR**
<!--- Describe what the PR holds -->

**Type of change**
<!--- Pick one below and delete the rest: -->

Feature Pull Request
Bugfix Pull Request
Docs Pull Request

**Fixes an issue**
<!--- If this PR fixes an issue, please mention it. -->
