### PR TITLE
Added zabbix_proxy_enableremotecommands variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,6 +40,7 @@ zabbix_proxy_listenport: 10051
 zabbix_proxy_sourceip:
 zabbix_proxy_logfile: /var/log/zabbix/zabbix_proxy.log
 zabbix_proxy_logfilesize: 10
+zabbix_proxy_enableremotecommands: 0
 zabbix_proxy_debuglevel: 3
 zabbix_proxy_pidfile: /var/run/zabbix/zabbix_proxy.pid
 zabbix_proxy_socketdir: /var/run/zabbix

--- a/templates/zabbix_proxy.conf.j2
+++ b/templates/zabbix_proxy.conf.j2
@@ -62,6 +62,13 @@ LogFile={{ zabbix_proxy_logfile }}
 #
 LogFileSize={{ zabbix_proxy_logfilesize }}
 
+### Option: EnableRemoteCommands
+#	Whether remote commands from Zabbix server are allowed.
+#	0 - not allowed
+#	1 - allowed
+#
+EnableRemoteCommands={{ zabbix_proxy_enableremotecommands }}
+
 ### Option: DebugLevel
 #	Specifies debug level
 #	0 - no debug


### PR DESCRIPTION
**Description of PR**
Added setting to zabbix proxy config template, so remote commands execution on proxies could be enabled (feature available since zabbix 4.0)

**Type of change**
Feature Pull Request

