### PR TITLE
implement a condition on the SocketDir parameter

### DIFF
--- a/templates/zabbix_proxy.conf.j2
+++ b/templates/zabbix_proxy.conf.j2
@@ -83,12 +83,12 @@ DebugLevel={{ zabbix_proxy_debuglevel }}
 #	Name of PID file.
 #
 PidFile={{ zabbix_proxy_pidfile }}
-
+{% if zabbix_version is version('3.2', '>') %}
 ### Option: SocketDir
 #	Location of the socketfile
 #
 SocketDir={{ zabbix_proxy_socketdir }}
-
+{% endif %}
 ### Option: DBHost
 #	Database host name.
 #	If set to localhost, socket is used for MySQL.


### PR DESCRIPTION
**Description of PR**
<!--- Describe what the PR holds -->
`SocketDir` is a new parameter that was implemented starting from version 3.4 so we need to skip this parameter if we're running on version equal or less than 3.4.
This fix the playbook on zabbix-proxy =< 3.2.
Without this condition, the _zabbix-proxy_ daemon will refuse to start with an invalid parameter error.
For reference: https://www.zabbix.com/documentation/3.4/manual/introduction/whatsnew340

**Type of change**
<!--- Pick one below and delete the rest: -->
Bugfix Pull Request


**Fixes an issue**
<!--- If this PR fixes an issue, please mention it. -->
