### PR TITLE
Add Proxy creation on through API

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ See the following list of supported Operating systems with the Zabbix releases.
 
 # Role Variables
 
+## Main variables
+
 There are some variables in de default/main.yml which can (Or needs to) be changed/overriden:
 
 * `zabbix_server_host`: The ip or dns name for the zabbix-server machine.
@@ -152,6 +154,10 @@ There are some variables in de default/main.yml which can (Or needs to) be chang
 * `*zabbix_proxy_package_state`: Default: _present_. Can be overridden to "latest" to update packages when needed.
 
 * `zabbix_proxy_install_database_client`: True / False. False does not install database client. Default: True.
+
+* `zabbix_agent_become_on_localhost`: Set to `False` if you don't need to elevate privileges on localhost to install packages locally with pip. Default: True
+
+* `zabbix_install_pip_packages`: Set to `False` if you don't want to install the required pip packages. Useful when you control your environment completely. Default: True
 
 There are some zabbix-proxy specific variables which will be used for the zabbix-proxy configuration file, these can be found in the default/main.yml file. There are 2 which needs some explanation:
 
@@ -170,6 +176,63 @@ If you use mysql, then you should define mysql username, password and host to pr
    zabbix_proxy_mysql_login_host
    zabbix_proxy_mysql_login_user
    zabbix_proxy_mysql_login_password
+
+## TLS Specific configuration
+
+These variables are specific for Zabbix 3.0 and higher:
+
+* `*zabbix_proxy_tlsconnect`: How the proxy should connect to server or proxy. Used for active checks.
+
+     Possible values:
+     
+     * no_encryption
+     * PSK
+     * certificate
+     
+* `*zabbix_proxy_tlsaccept`: What incoming connections to accept.
+
+     Possible values:
+     
+     * no_encryption
+     * PSK
+     * certificate
+
+* `*zabbix_proxy_tlscafile`: Full pathname of a file containing the top-level CA(s) certificates for peer certificate verification.
+
+* `*zabbix_proxy_tlscrlfile`: Full pathname of a file containing revoked certificates.
+
+* `*zabbix_proxy_tlsservercertissuer`: Allowed server certificate issuer.
+
+* `*zabbix_proxy_tlsservercertsubject`: Allowed server certificate subject.
+
+* `*zabbix_proxy_tlscertfile`: Full pathname of a file containing the agent certificate or certificate chain.
+
+* `*zabbix_proxy_tlskeyfile`: Full pathname of a file containing the agent private key.
+
+* `*zabbix_proxy_tlspskidentity`: Unique, case sensitive string used to identify the pre-shared key.
+
+## Zabbix API variables
+
+These variables need to be overridden when you want to make use of the zabbix-api for automatically creating and or updating hosts.
+
+Host encryption configuration will be set to match agent configuration.
+
+When `zabbix_api_create_proxy` is set to `True`, it will install on the host executing the Ansible playbook the `zabbix-api` python module.
+
+* `zabbix_url`: The url on which the Zabbix webpage is available. Example: http://zabbix.example.com
+
+* `zabbix_api_http_user`: The http user to access zabbix url with Basic Auth
+* `zabbix_api_http_password`: The http password to access zabbix url with Basic Auth
+
+* `zabbix_api_create_proxy`: When you want to enable the Zabbix API to create/delete the proxy. This has to be set to `True` if you want to make use of `zabbix_create_proxy`. Default: `False`
+
+* `zabbix_api_user`: Username of user which has API access.
+
+* `zabbix_api_pass`: Password for the user which has API access.
+
+* `zabbix_create_proxy`: present (Default) if the proxy needs to be created or absent if you want to delete it. This only works when `zabbix_api_create_proxy` is set to `True`.
+
+* `zabbix_proxy_status`: active (Default) if the proxy needs to be active or passive.
 
 # Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@ zabbix_version: 4.4
 zabbix_repo: zabbix
 zabbix_proxy_package_state: present
 zabbix_proxy_install_database_client: True
+zabbix_install_pip_packages: true
 
 zabbix_repo_yum:
   - name: zabbix
@@ -113,3 +114,26 @@ zabbix_proxy_tlsservercertsubject:
 zabbix_proxy_tlscertfile:
 zabbix_proxy_tlskeyfile:
 zabbix_proxy_tlspskidentity:
+
+zabbix_proxy_tls_config:
+  no_encryption: 'no_encryption'
+  PSK: 'PSK'
+  certificate: 'certificate'
+
+# Zabbix API stuff
+zabbix_url: "http://zabbix.dj-wasabi.local"
+# zabbix_api_http_user: admin
+# zabbix_api_http_password: admin
+zabbix_api_user: Admin
+zabbix_api_pass: zabbix
+zabbix_api_create_proxy: False
+zabbix_create_proxy: present  # or absent
+zabbix_proxy_status: active   # or passive
+zabbix_proxy: null
+zabbix_useuip: 1
+zabbix_proxy_become_on_localhost: True
+zabbix_proxy_interface:
+  useip: "{{ zabbix_useuip }}"
+  ip: "{{ zabbix_proxy_ip }}"
+  dns: "{{ ansible_fqdn }}"
+  port: "{{ zabbix_proxy_listenport }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -87,6 +87,44 @@
     mode: 0644
   notify: restart zabbix-proxy
 
+- name: "Installing the Zabbix-api package on localhost"
+  pip:
+    name: zabbix-api
+    state: present
+  register: zabbix_api_package_installed
+  until: zabbix_api_package_installed is succeeded
+  delegate_to: localhost
+  become: "{{ zabbix_proxy_become_on_localhost }}"
+  when:
+    - zabbix_install_pip_packages | bool
+    - zabbix_api_create_proxy | bool
+  tags:
+    - api
+
+- name: "Create proxy"
+  zabbix_proxy:
+    server_url: "{{ zabbix_url }}"
+    http_login_user: "{{ zabbix_api_http_user | default(omit) }}"
+    http_login_password: "{{ zabbix_api_http_password | default(omit) }}"
+    login_user: "{{ zabbix_api_user }}"
+    login_password: "{{ zabbix_api_pass }}"
+    state: "{{ zabbix_create_proxy }}"
+    status: "{{ zabbix_proxy_status }}"
+    proxy_name: "{{ zabbix_proxy_name }}"
+    description: "{{ zabbix_proxy_description | default(omit) }}"
+    tls_psk: "{{ zabbix_proxy_tlspsk_secret | default(omit) }}"
+    tls_psk_identity: "{{ zabbix_proxy_tlspskidentity | default(omit) }}"
+    tls_subject: "{{ zabbix_proxy_tlsservercertsubject | default(omit) }}"
+    tls_accept: "{{ zabbix_proxy_tls_config[zabbix_proxy_tlsaccept if zabbix_proxy_tlsaccept else 'no_encryption'] }}"
+    tls_connect: "{{ zabbix_proxy_tls_config[zabbix_proxy_tlsconnect if zabbix_proxy_tlsconnect else 'no_encryption'] }}"
+    validate_certs: "{{ zabbix_validate_certs | default(omit) }}"
+  when:
+    - zabbix_api_create_proxy | bool
+  delegate_to: localhost
+  become: no
+  tags:
+    - api
+
 - name: "zabbix-proxy started"
   service:
     name: zabbix-proxy


### PR DESCRIPTION
**Description of PR**
As we can create Host and HostGroup on ansible-zabbix-agent, I need to be able to create Proxy on Zabbix API.
I add the option to create the proxy through Zabbix API.

**Type of change**

Feature Pull Request

**Fixes an issue**
