### PR TITLE
ability to manage zabbix-proxy service

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ There are some variables in de default/main.yml which can (Or needs to) be chang
 
 * `zabbix_agent_become_on_localhost`: Set to `False` if you don't need to elevate privileges on localhost to install packages locally with pip. Default: True
 
+* `zabbix_proxy_manage_service`: True / False. When you run multiple Zabbix proxies in a High Available cluster setup (e.g. pacemaker), you don't want Ansible to manage the zabbix-proxy service, because Pacemaker is in control of zabbix-proxy service.
+
 * `zabbix_install_pip_packages`: Set to `False` if you don't want to install the required pip packages. Useful when you control your environment completely. Default: True
 
 There are some zabbix-proxy specific variables which will be used for the zabbix-proxy configuration file, these can be found in the default/main.yml file. There are 2 which needs some explanation:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -103,6 +103,7 @@ zabbix_proxy_allowroot: 0
 zabbix_proxy_include: /etc/zabbix/zabbix_proxy.conf.d
 zabbix_proxy_libdir: /usr/lib/zabbix
 zabbix_proxy_loadmodulepath: "{{ zabbix_proxy_libdir }}/modules"
+zabbix_proxy_manage_service: True
 
 # TLS settings
 zabbix_proxy_tlsconnect:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,3 +7,4 @@
     state: restarted
     enabled: yes
   become: yes
+  when: zabbix_proxy_manage_service | bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -131,3 +131,4 @@
     state: started
     enabled: yes
   become: yes
+  when: zabbix_proxy_manage_service | bool


### PR DESCRIPTION
**Description of PR**
When you run Zabbix proxy in a HA cluster setup you want the resource manager (e.g. Pacemaker) to have control about the zabbix-proxy service instead of Ansible. Starting zabbix-proxy on the passive node isn't necessary. By telling Ansible whether or not it has to manage the service, you can use this role in a HA cluster.

<!--- Describe what the PR holds -->
Feature Pull Request